### PR TITLE
Init Icons component

### DIFF
--- a/projects/fractally/packages/components/package.json
+++ b/projects/fractally/packages/components/package.json
@@ -13,6 +13,9 @@
         "react": "~17.0.0"
     },
     "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.1.0",
+        "@fortawesome/free-solid-svg-icons": "^6.1.0",
+        "@fortawesome/react-fontawesome": "^0.1.18",
         "react-icons": "^4.3.1",
         "react-modal": "^3.14.4"
     },

--- a/projects/fractally/packages/components/src/stories/Icon.stories.tsx
+++ b/projects/fractally/packages/components/src/stories/Icon.stories.tsx
@@ -7,10 +7,14 @@ export default {
     component: Icon,
 } as ComponentMeta<typeof Icon>;
 
-const Template: ComponentStory<typeof Icon> = (args) => <Icon {...args} />;
+const Template: ComponentStory<typeof Icon> = (args) => (
+    <div className="w-80">
+        <Icon {...args} />
+    </div>
+);
 
 export const Default = Template.bind({});
 Default.args = {
-    type: "dragon",
+    type: "coffee",
     size: "sm",
 };

--- a/projects/fractally/packages/components/src/stories/Icon.stories.tsx
+++ b/projects/fractally/packages/components/src/stories/Icon.stories.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import { Icon } from "../ui/Icon";
+
+export default {
+    component: Icon,
+} as ComponentMeta<typeof Icon>;
+
+const Template: ComponentStory<typeof Icon> = (args) => <Icon {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+    type: "dragon",
+    size: "sm",
+};

--- a/projects/fractally/packages/components/src/ui/Icon.tsx
+++ b/projects/fractally/packages/components/src/ui/Icon.tsx
@@ -1,0 +1,35 @@
+import React, { FC, SVGProps } from "react";
+import { BsChevronUp } from "react-icons/bs";
+import { FaDragon } from "react-icons/fa";
+
+import LoadingIcon from "./icons/LoadingIcon";
+
+export type IconSize = "xs" | "sm" | "md" | "lg";
+const SIZES: { [key in IconSize]: string } = {
+    xs: "w-2 h-2",
+    sm: "w-4 h-4",
+    md: "w-8 h-8",
+    lg: "w-16 h-16",
+};
+
+export type IconType = "loading" | "dragon" | "chevron-up";
+
+export type IconProps = {
+    type: IconType;
+    size?: IconSize;
+    className?: string;
+};
+
+const ICONS: { [key in IconType]: FC<SVGProps<SVGSVGElement>> } = {
+    loading: LoadingIcon,
+    dragon: FaDragon,
+    ["chevron-up"]: BsChevronUp,
+};
+
+export const Icon = ({ type, size = "sm", className }: IconProps) => {
+    const IconComponent = ICONS[type];
+    const iconClass = `flex-no-shrink fill-current ${SIZES[size]} ${
+        className || ""
+    }`;
+    return <IconComponent className={iconClass} />;
+};

--- a/projects/fractally/packages/components/src/ui/Icon.tsx
+++ b/projects/fractally/packages/components/src/ui/Icon.tsx
@@ -1,35 +1,48 @@
 import React, { FC, SVGProps } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCoffee, IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import { BsChevronUp } from "react-icons/bs";
 import { FaDragon } from "react-icons/fa";
 
 import LoadingIcon from "./icons/LoadingIcon";
 
-export type IconSize = "xs" | "sm" | "md" | "lg";
+export type IconProps = {
+    type: IconType;
+    size?: IconSize;
+    color?: IconColor;
+    className?: string;
+};
+
+export type IconSize = "sm" | "md" | "lg";
 const SIZES: { [key in IconSize]: string } = {
-    xs: "w-2 h-2",
     sm: "w-4 h-4",
     md: "w-8 h-8",
     lg: "w-16 h-16",
 };
 
-export type IconType = "loading" | "dragon" | "chevron-up";
-
-export type IconProps = {
-    type: IconType;
-    size?: IconSize;
-    className?: string;
+export type IconColor = "primary" | "disabled" | "caution" | "danger";
+const COLORS: { [key in IconColor]: string } = {
+    primary: "text-blue-500",
+    disabled: "text-gray-300",
+    caution: "text-yellow-500",
+    danger: "text-red-500",
 };
 
+const Fa6Wrapper = (icon: IconDefinition) => (props) =>
+    <FontAwesomeIcon icon={icon} {...props} />;
+
+export type IconType = "coffee" | "chevronUp" | "dragon" | "loading";
 const ICONS: { [key in IconType]: FC<SVGProps<SVGSVGElement>> } = {
-    loading: LoadingIcon,
+    coffee: Fa6Wrapper(faCoffee),
+    chevronUp: BsChevronUp,
     dragon: FaDragon,
-    ["chevron-up"]: BsChevronUp,
+    loading: LoadingIcon,
 };
 
-export const Icon = ({ type, size = "sm", className }: IconProps) => {
+export const Icon = ({ type, className = "", size, color }: IconProps) => {
     const IconComponent = ICONS[type];
-    const iconClass = `flex-no-shrink fill-current ${SIZES[size]} ${
-        className || ""
-    }`;
+    const colorClass = COLORS[color] || "";
+    const sizeClass = SIZES[size] || "";
+    const iconClass = `flex-no-shrink fill-current ${sizeClass} ${colorClass} ${className}`;
     return <IconComponent className={iconClass} />;
 };

--- a/projects/fractally/pnpm-lock.yaml
+++ b/projects/fractally/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
   packages/components:
     specifiers:
       '@babel/core': ^7.16.12
+      '@fortawesome/fontawesome-svg-core': ^6.1.0
+      '@fortawesome/free-solid-svg-icons': ^6.1.0
+      '@fortawesome/react-fontawesome': ^0.1.18
       '@storybook/addon-actions': ^6.4.15
       '@storybook/addon-essentials': ^6.4.15
       '@storybook/addon-links': ^6.4.15
@@ -191,15 +194,18 @@ importers:
       rimraf: ~3.0.2
       tailwindcss: ^3.0.18
     dependencies:
+      '@fortawesome/fontawesome-svg-core': 6.1.0
+      '@fortawesome/free-solid-svg-icons': 6.1.0
+      '@fortawesome/react-fontawesome': 0.1.18_d2d03af444233300c17090fb2cc105c2
       react-icons: 4.3.1_react@17.0.2
       react-modal: 3.14.4_react-dom@17.0.2+react@17.0.2
     devDependencies:
       '@babel/core': 7.16.12
       '@storybook/addon-actions': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
-      '@storybook/addon-essentials': 6.4.15_60a2637506b2f948f273a60c00ded899
+      '@storybook/addon-essentials': 6.4.15_da3ab8042eeb6e439b037251c9730bab
       '@storybook/addon-links': 6.4.15_react-dom@17.0.2+react@17.0.2
       '@storybook/addon-postcss': 2.0.0
-      '@storybook/react': 6.4.15_5c2a74fb55789be4e7552f73e529cd65
+      '@storybook/react': 6.4.15_a32301d14c29c100292f785e12405c66
       '@tailwindcss/forms': 0.4.0_tailwindcss@3.0.18
       '@types/react': 17.0.38
       '@types/react-modal': 3.13.1
@@ -1998,6 +2004,39 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@fortawesome/fontawesome-common-types/6.1.0:
+    resolution: {integrity: sha512-lFIJ5opxOKG9q88xOsuJJAdRZ+2WRldsZwUR/7MJoOMUMhF/LkHUjwWACIEPTa5Wo6uTDHvGRIX+XutdN7zYxA==}
+    engines: {node: '>=6'}
+    requiresBuild: true
+    dev: false
+
+  /@fortawesome/fontawesome-svg-core/6.1.0:
+    resolution: {integrity: sha512-racj+/EDnMZN0jcuHePOa+9kdHHOCpCAbBvVRnEi4G4DA5SWQiT/uXJ8WcfVEbLN51vPJjhukP4o+zH0cfYplg==}
+    engines: {node: '>=6'}
+    requiresBuild: true
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 6.1.0
+    dev: false
+
+  /@fortawesome/free-solid-svg-icons/6.1.0:
+    resolution: {integrity: sha512-OOr0jRHl5d41RzBS3sZh5Z3HmdPjMr43PxxKlYeLtQxFSixPf4sJFVM12/rTepB2m0rVShI0vtjHQmzOTlBaXg==}
+    engines: {node: '>=6'}
+    requiresBuild: true
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 6.1.0
+    dev: false
+
+  /@fortawesome/react-fontawesome/0.1.18_d2d03af444233300c17090fb2cc105c2:
+    resolution: {integrity: sha512-RwLIB4TZw0M9gvy5u+TusAA0afbwM4JQIimNH/j3ygd6aIvYPQLqXMhC9ErY26J23rDPyDZldIfPq/HpTTJ/tQ==}
+    peerDependencies:
+      '@fortawesome/fontawesome-svg-core': ~1 || ~6
+      react: '>=16.x'
+    dependencies:
+      '@fortawesome/fontawesome-svg-core': 6.1.0
+      prop-types: 15.8.1
+      react: 17.0.2
+    dev: false
 
   /@gar/promisify/1.1.2:
     resolution: {integrity: sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==}
@@ -4181,7 +4220,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/addon-controls/6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f:
+  /@storybook/addon-controls/6.4.15_431bdb1592e33ef2c62b821757768a09:
     resolution: {integrity: sha512-cl0aZ42YzsrzCSRHqzLz3d6mifGVrXflozsxYwliRMzc5noRbTzP1pQjwbKAveo9bqu0Er+siCMhJJYKZRtN4A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -4196,7 +4235,7 @@ packages:
       '@storybook/api': 6.4.15_react-dom@17.0.2+react@17.0.2
       '@storybook/client-logger': 6.4.15
       '@storybook/components': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
-      '@storybook/core-common': 6.4.15_react-dom@17.0.2+react@17.0.2
+      '@storybook/core-common': 6.4.15_ad2cdf9c00824bda00bb5f05ada1ee00
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/node-logger': 6.4.15
       '@storybook/store': 6.4.15_react-dom@17.0.2+react@17.0.2
@@ -4216,7 +4255,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-docs/6.4.15_e9a959e7756b7361993311033a764189:
+  /@storybook/addon-docs/6.4.15_f1dc2dbf85b52f83aa36c667c0fd1313:
     resolution: {integrity: sha512-0US2y9Gy4BECkulUA3womApCXNlmCYnhxcMikupolgcJOf/ZXH5w9l9r7mUCYIbaOr7WeU1UxwENF0GbF9jEUg==}
     peerDependencies:
       '@storybook/angular': 6.4.15
@@ -4274,17 +4313,17 @@ packages:
       '@mdx-js/react': 1.6.22_react@17.0.2
       '@storybook/addons': 6.4.15_react-dom@17.0.2+react@17.0.2
       '@storybook/api': 6.4.15_react-dom@17.0.2+react@17.0.2
-      '@storybook/builder-webpack4': 6.4.15_985971b6a7ced0631ea63014eadb9dfe
+      '@storybook/builder-webpack4': 6.4.15_ff57b8d70776f887320e581cd1ca70ea
       '@storybook/client-logger': 6.4.15
       '@storybook/components': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
-      '@storybook/core': 6.4.15_985971b6a7ced0631ea63014eadb9dfe
+      '@storybook/core': 6.4.15_ff57b8d70776f887320e581cd1ca70ea
       '@storybook/core-events': 6.4.15
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/csf-tools': 6.4.15
       '@storybook/node-logger': 6.4.15
       '@storybook/postinstall': 6.4.15
       '@storybook/preview-web': 6.4.15_react-dom@17.0.2+react@17.0.2
-      '@storybook/react': 6.4.15_5c2a74fb55789be4e7552f73e529cd65
+      '@storybook/react': 6.4.15_a32301d14c29c100292f785e12405c66
       '@storybook/source-loader': 6.4.15_react-dom@17.0.2+react@17.0.2
       '@storybook/store': 6.4.15_react-dom@17.0.2+react@17.0.2
       '@storybook/theming': 6.4.15_react-dom@17.0.2+react@17.0.2
@@ -4327,7 +4366,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-essentials/6.4.15_60a2637506b2f948f273a60c00ded899:
+  /@storybook/addon-essentials/6.4.15_da3ab8042eeb6e439b037251c9730bab:
     resolution: {integrity: sha512-np+CeBr1WdP+HngSt4I6DfT210cfAOPYlI18N0SncZomivMQQ8liAS9ICe+OXpCPCgF8bHDOtnrm6utvlJMoSg==}
     peerDependencies:
       '@babel/core': ^7.9.6
@@ -4355,8 +4394,8 @@ packages:
       '@babel/core': 7.16.12
       '@storybook/addon-actions': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
       '@storybook/addon-backgrounds': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
-      '@storybook/addon-controls': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
-      '@storybook/addon-docs': 6.4.15_e9a959e7756b7361993311033a764189
+      '@storybook/addon-controls': 6.4.15_431bdb1592e33ef2c62b821757768a09
+      '@storybook/addon-docs': 6.4.15_f1dc2dbf85b52f83aa36c667c0fd1313
       '@storybook/addon-measure': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
       '@storybook/addon-outline': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
       '@storybook/addon-toolbars': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
@@ -4584,7 +4623,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/builder-webpack4/6.4.15_985971b6a7ced0631ea63014eadb9dfe:
+  /@storybook/builder-webpack4/6.4.15_431bdb1592e33ef2c62b821757768a09:
     resolution: {integrity: sha512-1BE3lwE5M9w6Yhbc/X/z+/wpocYeKbKduoj5yetdRrlOTYpLHQdxvRmlmNjEz/azYS1xE2uXxxdsT9ZO7ZI36g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -4622,7 +4661,7 @@ packages:
       '@storybook/client-api': 6.4.15_react-dom@17.0.2+react@17.0.2
       '@storybook/client-logger': 6.4.15
       '@storybook/components': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
-      '@storybook/core-common': 6.4.15_react-dom@17.0.2+react@17.0.2
+      '@storybook/core-common': 6.4.15_ad2cdf9c00824bda00bb5f05ada1ee00
       '@storybook/core-events': 6.4.15
       '@storybook/node-logger': 6.4.15
       '@storybook/preview-web': 6.4.15_react-dom@17.0.2+react@17.0.2
@@ -4647,7 +4686,7 @@ packages:
       glob-promise: 3.4.0_glob@7.2.0
       global: 4.4.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
-      pnp-webpack-plugin: 1.6.4
+      pnp-webpack-plugin: 1.6.4_typescript@4.5.5
       postcss: 7.0.39
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 4.3.0_postcss@7.0.39+webpack@4.46.0
@@ -4656,8 +4695,9 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       stable: 0.1.8
       style-loader: 1.3.0_webpack@4.46.0
-      terser-webpack-plugin: 4.2.3_acorn@7.4.1+webpack@4.46.0
+      terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
+      typescript: 4.5.5
       url-loader: 4.1.1_file-loader@6.2.0+webpack@4.46.0
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -4675,7 +4715,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/builder-webpack4/6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f:
+  /@storybook/builder-webpack4/6.4.15_ff57b8d70776f887320e581cd1ca70ea:
     resolution: {integrity: sha512-1BE3lwE5M9w6Yhbc/X/z+/wpocYeKbKduoj5yetdRrlOTYpLHQdxvRmlmNjEz/azYS1xE2uXxxdsT9ZO7ZI36g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -4713,7 +4753,7 @@ packages:
       '@storybook/client-api': 6.4.15_react-dom@17.0.2+react@17.0.2
       '@storybook/client-logger': 6.4.15
       '@storybook/components': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
-      '@storybook/core-common': 6.4.15_react-dom@17.0.2+react@17.0.2
+      '@storybook/core-common': 6.4.15_ad2cdf9c00824bda00bb5f05ada1ee00
       '@storybook/core-events': 6.4.15
       '@storybook/node-logger': 6.4.15
       '@storybook/preview-web': 6.4.15_react-dom@17.0.2+react@17.0.2
@@ -4738,7 +4778,7 @@ packages:
       glob-promise: 3.4.0_glob@7.2.0
       global: 4.4.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
-      pnp-webpack-plugin: 1.6.4
+      pnp-webpack-plugin: 1.6.4_typescript@4.5.5
       postcss: 7.0.39
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 4.3.0_postcss@7.0.39+webpack@4.46.0
@@ -4747,8 +4787,9 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       stable: 0.1.8
       style-loader: 1.3.0_webpack@4.46.0
-      terser-webpack-plugin: 4.2.3_webpack@4.46.0
+      terser-webpack-plugin: 4.2.3_acorn@7.4.1+webpack@4.46.0
       ts-dedent: 2.2.0
+      typescript: 4.5.5
       url-loader: 4.1.1_file-loader@6.2.0+webpack@4.46.0
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -4869,7 +4910,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/core-client/6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f:
+  /@storybook/core-client/6.4.15_5dbfc3e80d296a51d14063737d30fddd:
     resolution: {integrity: sha512-hCsNNxgFUfLWzu5ZEd046RHyytVJi7++xX7tdKPVphKGiDHdRkmJEzN48+MohNVoRruMmKd/3GMbaYL8Sajrow==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -4900,43 +4941,7 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
-      unfetch: 4.2.0
-      util-deprecate: 1.0.2
-    transitivePeerDependencies:
-      - '@types/react'
-    dev: true
-
-  /@storybook/core-client/6.4.15_ea8b48f221ff72ac790ef9181ff36099:
-    resolution: {integrity: sha512-hCsNNxgFUfLWzu5ZEd046RHyytVJi7++xX7tdKPVphKGiDHdRkmJEzN48+MohNVoRruMmKd/3GMbaYL8Sajrow==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-      typescript: '*'
-      webpack: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@storybook/addons': 6.4.15_react-dom@17.0.2+react@17.0.2
-      '@storybook/channel-postmessage': 6.4.15
-      '@storybook/channel-websocket': 6.4.15
-      '@storybook/client-api': 6.4.15_react-dom@17.0.2+react@17.0.2
-      '@storybook/client-logger': 6.4.15
-      '@storybook/core-events': 6.4.15
-      '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/preview-web': 6.4.15_react-dom@17.0.2+react@17.0.2
-      '@storybook/store': 6.4.15_react-dom@17.0.2+react@17.0.2
-      '@storybook/ui': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
-      airbnb-js-shims: 2.2.1
-      ansi-to-html: 0.6.15
-      core-js: 3.20.3
-      global: 4.4.0
-      lodash: 4.17.21
-      qs: 6.10.3
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      regenerator-runtime: 0.13.9
-      ts-dedent: 2.2.0
+      typescript: 4.5.5
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -4944,7 +4949,45 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/core-common/6.4.15_react-dom@17.0.2+react@17.0.2:
+  /@storybook/core-client/6.4.15_64539567fecf02928f0b6f9bf2f8ff71:
+    resolution: {integrity: sha512-hCsNNxgFUfLWzu5ZEd046RHyytVJi7++xX7tdKPVphKGiDHdRkmJEzN48+MohNVoRruMmKd/3GMbaYL8Sajrow==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+      typescript: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@storybook/addons': 6.4.15_react-dom@17.0.2+react@17.0.2
+      '@storybook/channel-postmessage': 6.4.15
+      '@storybook/channel-websocket': 6.4.15
+      '@storybook/client-api': 6.4.15_react-dom@17.0.2+react@17.0.2
+      '@storybook/client-logger': 6.4.15
+      '@storybook/core-events': 6.4.15
+      '@storybook/csf': 0.0.2--canary.87bc651.0
+      '@storybook/preview-web': 6.4.15_react-dom@17.0.2+react@17.0.2
+      '@storybook/store': 6.4.15_react-dom@17.0.2+react@17.0.2
+      '@storybook/ui': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
+      airbnb-js-shims: 2.2.1
+      ansi-to-html: 0.6.15
+      core-js: 3.20.3
+      global: 4.4.0
+      lodash: 4.17.21
+      qs: 6.10.3
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      regenerator-runtime: 0.13.9
+      ts-dedent: 2.2.0
+      typescript: 4.5.5
+      unfetch: 4.2.0
+      util-deprecate: 1.0.2
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: true
+
+  /@storybook/core-common/6.4.15_ad2cdf9c00824bda00bb5f05ada1ee00:
     resolution: {integrity: sha512-KQgK04tXvf9sTAVUfDZTXMA1hSvi7bEdLZM1WsOu4Fk7TKch5tMvCHORlwbZnpslStiEsjolH0SN2c9E4n3OrA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -4987,7 +5030,7 @@ packages:
       express: 4.17.2
       file-system-cache: 1.0.5
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.0_webpack@4.46.0
+      fork-ts-checker-webpack-plugin: 6.5.0_8a2132c92b90deb4d3f8d77f63765a3c
       fs-extra: 9.1.0
       glob: 7.2.0
       handlebars: 4.7.7
@@ -5003,6 +5046,7 @@ packages:
       slash: 3.0.0
       telejson: 5.3.3
       ts-dedent: 2.2.0
+      typescript: 4.5.5
       util-deprecate: 1.0.2
       webpack: 4.46.0
     transitivePeerDependencies:
@@ -5019,7 +5063,7 @@ packages:
       core-js: 3.20.3
     dev: true
 
-  /@storybook/core-server/6.4.15_985971b6a7ced0631ea63014eadb9dfe:
+  /@storybook/core-server/6.4.15_431bdb1592e33ef2c62b821757768a09:
     resolution: {integrity: sha512-VtzWZwvquPQvE/wG9J4JYB3T3grMq5/pKU/V3VOPPzyFcnhJ5zgHaHyBzN0rlosKIbB4n3EzguIHKJ4OEu0HQA==}
     peerDependencies:
       '@storybook/builder-webpack5': 6.4.15
@@ -5036,13 +5080,13 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.6
-      '@storybook/builder-webpack4': 6.4.15_985971b6a7ced0631ea63014eadb9dfe
-      '@storybook/core-client': 6.4.15_ea8b48f221ff72ac790ef9181ff36099
-      '@storybook/core-common': 6.4.15_react-dom@17.0.2+react@17.0.2
+      '@storybook/builder-webpack4': 6.4.15_431bdb1592e33ef2c62b821757768a09
+      '@storybook/core-client': 6.4.15_5dbfc3e80d296a51d14063737d30fddd
+      '@storybook/core-common': 6.4.15_ad2cdf9c00824bda00bb5f05ada1ee00
       '@storybook/core-events': 6.4.15
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/csf-tools': 6.4.15
-      '@storybook/manager-webpack4': 6.4.15_985971b6a7ced0631ea63014eadb9dfe
+      '@storybook/manager-webpack4': 6.4.15_431bdb1592e33ef2c62b821757768a09
       '@storybook/node-logger': 6.4.15
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.4.15_react-dom@17.0.2+react@17.0.2
@@ -5075,6 +5119,7 @@ packages:
       slash: 3.0.0
       telejson: 5.3.3
       ts-dedent: 2.2.0
+      typescript: 4.5.5
       util-deprecate: 1.0.2
       watchpack: 2.3.1
       webpack: 4.46.0
@@ -5092,7 +5137,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core-server/6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f:
+  /@storybook/core-server/6.4.15_ff57b8d70776f887320e581cd1ca70ea:
     resolution: {integrity: sha512-VtzWZwvquPQvE/wG9J4JYB3T3grMq5/pKU/V3VOPPzyFcnhJ5zgHaHyBzN0rlosKIbB4n3EzguIHKJ4OEu0HQA==}
     peerDependencies:
       '@storybook/builder-webpack5': 6.4.15
@@ -5109,13 +5154,13 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.6
-      '@storybook/builder-webpack4': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
-      '@storybook/core-client': 6.4.15_ea8b48f221ff72ac790ef9181ff36099
-      '@storybook/core-common': 6.4.15_react-dom@17.0.2+react@17.0.2
+      '@storybook/builder-webpack4': 6.4.15_ff57b8d70776f887320e581cd1ca70ea
+      '@storybook/core-client': 6.4.15_5dbfc3e80d296a51d14063737d30fddd
+      '@storybook/core-common': 6.4.15_ad2cdf9c00824bda00bb5f05ada1ee00
       '@storybook/core-events': 6.4.15
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/csf-tools': 6.4.15
-      '@storybook/manager-webpack4': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
+      '@storybook/manager-webpack4': 6.4.15_ff57b8d70776f887320e581cd1ca70ea
       '@storybook/node-logger': 6.4.15
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.4.15_react-dom@17.0.2+react@17.0.2
@@ -5148,6 +5193,7 @@ packages:
       slash: 3.0.0
       telejson: 5.3.3
       ts-dedent: 2.2.0
+      typescript: 4.5.5
       util-deprecate: 1.0.2
       watchpack: 2.3.1
       webpack: 4.46.0
@@ -5165,7 +5211,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core/6.4.15_985971b6a7ced0631ea63014eadb9dfe:
+  /@storybook/core/6.4.15_d28588b8fbcd5da54580026485e41173:
     resolution: {integrity: sha512-fSMGj17GwzT7lNMJ19d4+EzUOrAgdBwUwotjkXsfkFxWFvBMN+9jb28iuzr7lZ8xod6ClurKH9lGwucvYDgfpA==}
     peerDependencies:
       '@storybook/builder-webpack5': 6.4.15
@@ -5179,10 +5225,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-client': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
-      '@storybook/core-server': 6.4.15_985971b6a7ced0631ea63014eadb9dfe
+      '@storybook/core-client': 6.4.15_5dbfc3e80d296a51d14063737d30fddd
+      '@storybook/core-server': 6.4.15_431bdb1592e33ef2c62b821757768a09
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
+      typescript: 4.5.5
+      webpack: 4.46.0
     transitivePeerDependencies:
       - '@storybook/manager-webpack5'
       - '@types/react'
@@ -5197,7 +5245,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core/6.4.15_ea8b48f221ff72ac790ef9181ff36099:
+  /@storybook/core/6.4.15_ff57b8d70776f887320e581cd1ca70ea:
     resolution: {integrity: sha512-fSMGj17GwzT7lNMJ19d4+EzUOrAgdBwUwotjkXsfkFxWFvBMN+9jb28iuzr7lZ8xod6ClurKH9lGwucvYDgfpA==}
     peerDependencies:
       '@storybook/builder-webpack5': 6.4.15
@@ -5211,11 +5259,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-client': 6.4.15_ea8b48f221ff72ac790ef9181ff36099
-      '@storybook/core-server': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
+      '@storybook/core-client': 6.4.15_64539567fecf02928f0b6f9bf2f8ff71
+      '@storybook/core-server': 6.4.15_ff57b8d70776f887320e581cd1ca70ea
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      webpack: 4.46.0
+      typescript: 4.5.5
     transitivePeerDependencies:
       - '@storybook/manager-webpack5'
       - '@types/react'
@@ -5260,7 +5308,7 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /@storybook/manager-webpack4/6.4.15_985971b6a7ced0631ea63014eadb9dfe:
+  /@storybook/manager-webpack4/6.4.15_431bdb1592e33ef2c62b821757768a09:
     resolution: {integrity: sha512-2RAfkZYQWerLF3yJPrjWe2Rmjx8cKOPlsxnADB/dJOefI4MkVuLnLxFljt/ze0JTSceCzLv8A6Rebog6jREu8w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -5274,8 +5322,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.16.7_@babel+core@7.16.12
       '@babel/preset-react': 7.16.7_@babel+core@7.16.12
       '@storybook/addons': 6.4.15_react-dom@17.0.2+react@17.0.2
-      '@storybook/core-client': 6.4.15_ea8b48f221ff72ac790ef9181ff36099
-      '@storybook/core-common': 6.4.15_react-dom@17.0.2+react@17.0.2
+      '@storybook/core-client': 6.4.15_5dbfc3e80d296a51d14063737d30fddd
+      '@storybook/core-common': 6.4.15_ad2cdf9c00824bda00bb5f05ada1ee00
       '@storybook/node-logger': 6.4.15
       '@storybook/theming': 6.4.15_react-dom@17.0.2+react@17.0.2
       '@storybook/ui': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
@@ -5293,7 +5341,7 @@ packages:
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
       node-fetch: 2.6.7
-      pnp-webpack-plugin: 1.6.4
+      pnp-webpack-plugin: 1.6.4_typescript@4.5.5
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       read-pkg-up: 7.0.1
@@ -5301,8 +5349,9 @@ packages:
       resolve-from: 5.0.0
       style-loader: 1.3.0_webpack@4.46.0
       telejson: 5.3.3
-      terser-webpack-plugin: 4.2.3_acorn@7.4.1+webpack@4.46.0
+      terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
+      typescript: 4.5.5
       url-loader: 4.1.1_file-loader@6.2.0+webpack@4.46.0
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -5319,7 +5368,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/manager-webpack4/6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f:
+  /@storybook/manager-webpack4/6.4.15_ff57b8d70776f887320e581cd1ca70ea:
     resolution: {integrity: sha512-2RAfkZYQWerLF3yJPrjWe2Rmjx8cKOPlsxnADB/dJOefI4MkVuLnLxFljt/ze0JTSceCzLv8A6Rebog6jREu8w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -5333,8 +5382,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.16.7_@babel+core@7.16.12
       '@babel/preset-react': 7.16.7_@babel+core@7.16.12
       '@storybook/addons': 6.4.15_react-dom@17.0.2+react@17.0.2
-      '@storybook/core-client': 6.4.15_ea8b48f221ff72ac790ef9181ff36099
-      '@storybook/core-common': 6.4.15_react-dom@17.0.2+react@17.0.2
+      '@storybook/core-client': 6.4.15_5dbfc3e80d296a51d14063737d30fddd
+      '@storybook/core-common': 6.4.15_ad2cdf9c00824bda00bb5f05ada1ee00
       '@storybook/node-logger': 6.4.15
       '@storybook/theming': 6.4.15_react-dom@17.0.2+react@17.0.2
       '@storybook/ui': 6.4.15_b3482aaf5744fc7c2aeb7941b0e0a78f
@@ -5352,7 +5401,7 @@ packages:
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
       node-fetch: 2.6.7
-      pnp-webpack-plugin: 1.6.4
+      pnp-webpack-plugin: 1.6.4_typescript@4.5.5
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       read-pkg-up: 7.0.1
@@ -5360,8 +5409,9 @@ packages:
       resolve-from: 5.0.0
       style-loader: 1.3.0_webpack@4.46.0
       telejson: 5.3.3
-      terser-webpack-plugin: 4.2.3_webpack@4.46.0
+      terser-webpack-plugin: 4.2.3_acorn@7.4.1+webpack@4.46.0
       ts-dedent: 2.2.0
+      typescript: 4.5.5
       url-loader: 4.1.1_file-loader@6.2.0+webpack@4.46.0
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -5420,7 +5470,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.253f8c1.0_webpack@4.46.0:
+  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.253f8c1.0_typescript@4.5.5+webpack@4.46.0:
     resolution: {integrity: sha512-mmoRG/rNzAiTbh+vGP8d57dfcR2aP+5/Ll03KKFyfy5FqWFm/Gh7u27ikx1I3LmVMI8n6jh5SdWMkMKon7/tDw==}
     peerDependencies:
       typescript: '>= 3.x'
@@ -5431,14 +5481,15 @@ packages:
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
       micromatch: 4.0.4
-      react-docgen-typescript: 2.2.2
+      react-docgen-typescript: 2.2.2_typescript@4.5.5
       tslib: 2.3.1
+      typescript: 4.5.5
       webpack: 4.46.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@storybook/react/6.4.15_5c2a74fb55789be4e7552f73e529cd65:
+  /@storybook/react/6.4.15_a32301d14c29c100292f785e12405c66:
     resolution: {integrity: sha512-SWtZeG+3Mx3PAaKLy/v/GlNN3PLxVacm53RmhayhFVCWvbSazNZn/3xnTUzpVPYMsO7QEqF/NWmC1YUndSoo6Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -5458,11 +5509,11 @@ packages:
       '@babel/preset-react': 7.16.7_@babel+core@7.16.12
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.4_06cd85ae30adde416cafc06517ba554d
       '@storybook/addons': 6.4.15_react-dom@17.0.2+react@17.0.2
-      '@storybook/core': 6.4.15_ea8b48f221ff72ac790ef9181ff36099
-      '@storybook/core-common': 6.4.15_react-dom@17.0.2+react@17.0.2
+      '@storybook/core': 6.4.15_d28588b8fbcd5da54580026485e41173
+      '@storybook/core-common': 6.4.15_ad2cdf9c00824bda00bb5f05ada1ee00
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/node-logger': 6.4.15
-      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.253f8c1.0_webpack@4.46.0
+      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.253f8c1.0_typescript@4.5.5+webpack@4.46.0
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.4.15_react-dom@17.0.2+react@17.0.2
       '@types/webpack-env': 1.16.3
@@ -5479,6 +5530,7 @@ packages:
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
+      typescript: 4.5.5
       webpack: 4.46.0
     transitivePeerDependencies:
       - '@storybook/builder-webpack5'
@@ -10305,6 +10357,38 @@ packages:
       worker-rpc: 0.1.1
     dev: true
 
+  /fork-ts-checker-webpack-plugin/6.5.0_8a2132c92b90deb4d3f8d77f63765a3c:
+    resolution: {integrity: sha512-cS178Y+xxtIjEUorcHddKS7yCMlrDPV31mt47blKKRfMd70Kxu5xruAFE2o9sDY6wVC5deuob/u/alD04YYHnw==}
+    engines: {node: '>=10', yarn: '>=1.0.0'}
+    peerDependencies:
+      eslint: '>= 6'
+      typescript: '>= 2.7'
+      vue-template-compiler: '*'
+      webpack: '>= 4'
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+      vue-template-compiler:
+        optional: true
+    dependencies:
+      '@babel/code-frame': 7.16.7
+      '@types/json-schema': 7.0.9
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      cosmiconfig: 6.0.0
+      deepmerge: 4.2.2
+      eslint: 8.7.0
+      fs-extra: 9.1.0
+      glob: 7.2.0
+      memfs: 3.4.1
+      minimatch: 3.0.4
+      schema-utils: 2.7.0
+      semver: 7.3.5
+      tapable: 1.1.3
+      typescript: 4.5.5
+      webpack: 4.46.0
+    dev: true
+
   /fork-ts-checker-webpack-plugin/6.5.0_ed06811c8a9a6a40c742358c93886fc9:
     resolution: {integrity: sha512-cS178Y+xxtIjEUorcHddKS7yCMlrDPV31mt47blKKRfMd70Kxu5xruAFE2o9sDY6wVC5deuob/u/alD04YYHnw==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
@@ -10335,36 +10419,6 @@ packages:
       tapable: 1.1.3
       typescript: 4.5.4
       webpack: 5.66.0
-    dev: true
-
-  /fork-ts-checker-webpack-plugin/6.5.0_webpack@4.46.0:
-    resolution: {integrity: sha512-cS178Y+xxtIjEUorcHddKS7yCMlrDPV31mt47blKKRfMd70Kxu5xruAFE2o9sDY6wVC5deuob/u/alD04YYHnw==}
-    engines: {node: '>=10', yarn: '>=1.0.0'}
-    peerDependencies:
-      eslint: '>= 6'
-      typescript: '>= 2.7'
-      vue-template-compiler: '*'
-      webpack: '>= 4'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      vue-template-compiler:
-        optional: true
-    dependencies:
-      '@babel/code-frame': 7.16.7
-      '@types/json-schema': 7.0.9
-      chalk: 4.1.2
-      chokidar: 3.5.3
-      cosmiconfig: 6.0.0
-      deepmerge: 4.2.2
-      fs-extra: 9.1.0
-      glob: 7.2.0
-      memfs: 3.4.1
-      minimatch: 3.0.4
-      schema-utils: 2.7.0
-      semver: 7.3.5
-      tapable: 1.1.3
-      webpack: 4.46.0
     dev: true
 
   /form-data-encoder/1.7.1:
@@ -14458,11 +14512,11 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /pnp-webpack-plugin/1.6.4:
+  /pnp-webpack-plugin/1.6.4_typescript@4.5.5:
     resolution: {integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==}
     engines: {node: '>=6'}
     dependencies:
-      ts-pnp: 1.2.0
+      ts-pnp: 1.2.0_typescript@4.5.5
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -14938,10 +14992,12 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: true
 
-  /react-docgen-typescript/2.2.2:
+  /react-docgen-typescript/2.2.2_typescript@4.5.5:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
+    dependencies:
+      typescript: 4.5.5
     dev: true
 
   /react-docgen/5.4.0:
@@ -17178,7 +17234,7 @@ packages:
       yn: 3.1.1
     dev: true
 
-  /ts-pnp/1.2.0:
+  /ts-pnp/1.2.0_typescript@4.5.5:
     resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
     engines: {node: '>=6'}
     peerDependencies:
@@ -17186,6 +17242,8 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+    dependencies:
+      typescript: 4.5.5
     dev: true
 
   /tsconfig-paths-webpack-plugin/3.5.2:


### PR DESCRIPTION
- Icons component: gives an unified and central palette of icons and sizes to be used (nice Dev eXperience (DX)):
<img width="778" alt="image" src="https://user-images.githubusercontent.com/79721020/158934665-e024fea1-6feb-4584-bd96-2fc4fec9af34.png">

- Decoupled from any libs! Want to use react-icons? Fine go ahead. Want to use fontawesome@6.9.1.23.4.6-master-release? Fine! go ahead! Want to use raw SVGs? Sure, why not?! (Of course we are assuming these libraries have a way to expose single icons for an effective tree-shaking when compiling our lib).
<img width="508" alt="image" src="https://user-images.githubusercontent.com/79721020/158934949-ce0f5b0c-de30-45f1-9383-10895f842987.png">

- By having a centralized icons palette we can detect and eliminate same icons that are imported by mistake. There's no reason for using `FaChevronUp` and `BsChevronUp` in different components, here we must pick only one. The developer adding the new icon will be conscious about the ones already exposed and available by simply skimming through this file.

- Component is a middle layer itself, it allows complex logic for handling different icon libs peculiarities if needed, abstracting it from a dev that just wants to consume it without dealing with corner cases.