### PR TITLE
SignalWire: Test highlight-1-responsive room layout

### DIFF
--- a/projects/fractally/apps/webapp/package.json
+++ b/projects/fractally/apps/webapp/package.json
@@ -14,6 +14,7 @@
     "dependencies": {
         "@fractally/components": "*",
         "@greymass/eosio": "^0.5.4",
+        "@signalwire/core": "^3.7.1",
         "@signalwire/js": "^3.10.2",
         "anchor-link": "^3.3.5",
         "anchor-link-browser-transport": "^3.2.5",

--- a/projects/fractally/apps/webapp/package.json
+++ b/projects/fractally/apps/webapp/package.json
@@ -14,7 +14,6 @@
     "dependencies": {
         "@fractally/components": "*",
         "@greymass/eosio": "^0.5.4",
-        "@signalwire/core": "^3.7.1",
         "@signalwire/js": "^3.10.2",
         "anchor-link": "^3.3.5",
         "anchor-link-browser-transport": "^3.2.5",

--- a/projects/fractally/apps/webapp/package.json
+++ b/projects/fractally/apps/webapp/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "@fractally/components": "*",
         "@greymass/eosio": "^0.5.4",
-        "@signalwire/core": "^3.4.1",
+        "@signalwire/core": "^3.7.1",
         "@signalwire/js": "^3.10.2",
         "anchor-link": "^3.3.5",
         "anchor-link-browser-transport": "^3.2.5",

--- a/projects/fractally/apps/webapp/src/app/video/components/in-call.tsx
+++ b/projects/fractally/apps/webapp/src/app/video/components/in-call.tsx
@@ -10,6 +10,7 @@ import {
     MuteVideoButton,
     Participants,
     ScreenShareButton,
+    ToggleLayoutButton,
     Video,
 } from ".";
 import { Participant, RoomUpdates } from "../interfaces";
@@ -181,6 +182,7 @@ export const InCall = ({ joinDetails, onLeave }) => {
                             <MdOutlineFullscreen size={22} className="mr-1" />
                             Full screen
                         </Button>
+                        <ToggleLayoutButton room={room} />
                         <Button onClick={handleLeaveClick} type="dangerOutline">
                             <MdOutlineExitToApp size={22} className="mr-1" />
                             Leave

--- a/projects/fractally/apps/webapp/src/app/video/components/index.ts
+++ b/projects/fractally/apps/webapp/src/app/video/components/index.ts
@@ -5,3 +5,4 @@ export * from "./mute-buttons";
 export * from "./participants";
 export * from "./video";
 export * from "./screen-share-button";
+export * from "./toggle-layout-button";

--- a/projects/fractally/apps/webapp/src/app/video/components/toggle-layout-button.tsx
+++ b/projects/fractally/apps/webapp/src/app/video/components/toggle-layout-button.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from "react";
+import * as SignalWire from "@signalwire/js";
+import { Button } from "@fractally/components/ui";
+
+interface ToggleLayoutButtonProps {
+    room: SignalWire.Video.RoomSession;
+}
+
+export const ToggleLayoutButton = ({ room }: ToggleLayoutButtonProps) => {
+    // obviously, this is just a rough POC
+    const layouts = {
+        grid: "grid-responsive",
+        highlight: "highlight-1-responsive",
+    };
+
+    const [layout, setLayout] = useState(layouts.grid);
+
+    const toggleLayout = async () => {
+        try {
+            if (layout === layouts.grid) {
+                await room.setLayout({ name: layouts.highlight });
+                setLayout(layouts.highlight);
+            } else {
+                await room.setLayout({ name: layouts.grid });
+                setLayout(layouts.grid);
+            }
+        } catch (e) {
+            console.error(e);
+            alert("fail to toggle layout: " + e);
+        }
+    };
+
+    return <Button onClick={toggleLayout}>Layout</Button>;
+};

--- a/projects/fractally/apps/webapp/src/app/video/components/video.tsx
+++ b/projects/fractally/apps/webapp/src/app/video/components/video.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import axios from "axios";
 import * as SignalWire from "@signalwire/js";
-import { VideoRoomSubscribedEventParams } from "@signalwire/core";
 
 import { coreApiBaseUrl } from "../../config";
 import { Participant, RoomUpdates } from "../interfaces";
@@ -91,7 +90,7 @@ export const Video = ({
                 eventLogger("room.joined - the event follows:");
                 console.log(e);
 
-                const event = e as VideoRoomSubscribedEventParams;
+                const event = e as any;
 
                 thisParticipantId.current = event.member_id;
                 onRoomUpdate({

--- a/projects/fractally/apps/webapp/src/app/video/components/video.tsx
+++ b/projects/fractally/apps/webapp/src/app/video/components/video.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import axios from "axios";
 import * as SignalWire from "@signalwire/js";
+import { VideoRoomSubscribedEventParams } from "@signalwire/core";
 
 import { coreApiBaseUrl } from "../../config";
 import { Participant, RoomUpdates } from "../interfaces";
@@ -90,7 +91,7 @@ export const Video = ({
                 eventLogger("room.joined - the event follows:");
                 console.log(e);
 
-                const event = e as any;
+                const event = e as VideoRoomSubscribedEventParams;
 
                 thisParticipantId.current = event.member_id;
                 onRoomUpdate({

--- a/projects/fractally/apps/webapp/src/app/video/components/video.tsx
+++ b/projects/fractally/apps/webapp/src/app/video/components/video.tsx
@@ -84,7 +84,6 @@ export const Video = ({
             const room = new SignalWire.Video.RoomSession({
                 token,
                 rootElement: document.getElementById("stream"), // an html element to display the video
-                video: true,
             });
 
             // Listen for room events

--- a/projects/fractally/apps/webapp/src/pages/api/get-token.tsx
+++ b/projects/fractally/apps/webapp/src/pages/api/get-token.tsx
@@ -131,7 +131,7 @@ const createRoom = async (roomName: string, expiresMinutes: number) => {
     const roomConfig: RoomConfig = {
         name: roomName,
         quality: "1080p",
-        layout: "highlight-1-responsive",
+        layout: "grid-responsive",
         record_on_start: false,
     };
 

--- a/projects/fractally/apps/webapp/src/pages/api/get-token.tsx
+++ b/projects/fractally/apps/webapp/src/pages/api/get-token.tsx
@@ -129,7 +129,7 @@ const createRoom = async (roomName: string, expiresMinutes: number) => {
     const roomConfig: RoomConfig = {
         name: roomName,
         quality: "1080p",
-        layout: "grid-responsive",
+        layout: "highlight-1-responsive",
         record_on_start: false,
     };
 

--- a/projects/fractally/apps/webapp/src/pages/api/get-token.tsx
+++ b/projects/fractally/apps/webapp/src/pages/api/get-token.tsx
@@ -36,6 +36,7 @@ const normalPermissions = [
     "room.self.set_input_sensitivity",
     "room.hide_video_muted",
     "room.show_video_muted",
+    "room.list_available_layouts",
     "room.set_layout",
 ];
 

--- a/projects/fractally/apps/webapp/src/pages/api/get-token.tsx
+++ b/projects/fractally/apps/webapp/src/pages/api/get-token.tsx
@@ -36,6 +36,7 @@ const normalPermissions = [
     "room.self.set_input_sensitivity",
     "room.hide_video_muted",
     "room.show_video_muted",
+    "room.set_layout",
 ];
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {

--- a/projects/fractally/pnpm-lock.yaml
+++ b/projects/fractally/pnpm-lock.yaml
@@ -97,7 +97,7 @@ importers:
       '@graphql-codegen/typescript-operations': 2.2.2
       '@graphql-codegen/typescript-react-query': ^3.4.0
       '@greymass/eosio': ^0.5.4
-      '@signalwire/core': ^3.4.1
+      '@signalwire/core': ^3.7.1
       '@signalwire/js': ^3.10.2
       '@tailwindcss/forms': ^0.4.0
       '@types/node': ~16.11.0
@@ -128,7 +128,7 @@ importers:
     dependencies:
       '@fractally/components': link:../../packages/components
       '@greymass/eosio': 0.5.4
-      '@signalwire/core': 3.4.1_react@17.0.2
+      '@signalwire/core': 3.7.1
       '@signalwire/js': 3.10.2
       anchor-link: 3.3.5
       anchor-link-browser-transport: 3.2.5_anchor-link@3.3.5
@@ -4077,24 +4077,6 @@ packages:
     resolution: {integrity: sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg==}
     dev: false
 
-  /@reduxjs/toolkit/1.7.1_react@17.0.2:
-    resolution: {integrity: sha512-wXwXYjBVz/ItxB7SMzEAMmEE/FBiY1ze18N+VVVX7NtVbRUrdOGKhpQMHivIJfkbJvSdLUU923a/yAagJQzY0Q==}
-    peerDependencies:
-      react: ^16.9.0 || ^17.0.0 || 18.0.0-beta
-      react-redux: ^7.2.1 || ^8.0.0-beta
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-redux:
-        optional: true
-    dependencies:
-      immer: 9.0.12
-      react: 17.0.2
-      redux: 4.1.2
-      redux-thunk: 2.4.1_redux@4.1.2
-      reselect: 4.1.5
-    dev: false
-
   /@rushstack/eslint-patch/1.1.0:
     resolution: {integrity: sha512-JLo+Y592QzIE+q7Dl2pMUtt4q8SKYI5jDrZxrozEQxnGVOyYE+GWK9eLkwTaeN9DDctlaRAQ3TBmzZ1qdLE30A==}
     dev: true
@@ -4114,20 +4096,6 @@ packages:
       any-observable: 0.3.0
       rxjs: 6.6.7
     dev: true
-
-  /@signalwire/core/3.4.1_react@17.0.2:
-    resolution: {integrity: sha512-lE8K6FeAKfnqrzjOaIe0O5sHBWp9uKtkGPKi+LKZrr10KLl7Ep/7WG4Ix6ctLBn8+c8utLYliRbkrW8oziTCLw==}
-    engines: {node: '>=10'}
-    dependencies:
-      '@redux-saga/core': 1.1.3
-      '@reduxjs/toolkit': 1.7.1_react@17.0.2
-      eventemitter3: 4.0.7
-      loglevel: 1.8.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - react
-      - react-redux
-    dev: false
 
   /@signalwire/core/3.7.1:
     resolution: {integrity: sha512-74Ir0nUKJpvyclN/VykKS04t7uGQb8cDBa3w1bMyiy5fdmYJ10heGIWCJX6Azrrq5UckmfPqkxpNoPS8A4gWNA==}
@@ -11410,10 +11378,6 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
-  /immer/9.0.12:
-    resolution: {integrity: sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA==}
-    dev: false
-
   /immutable/3.7.6:
     resolution: {integrity: sha1-E7TTyxK++hVIKib+Gy665kAHHks=}
     engines: {node: '>=0.8.0'}
@@ -15412,14 +15376,6 @@ packages:
       strip-indent: 3.0.0
     dev: true
 
-  /redux-thunk/2.4.1_redux@4.1.2:
-    resolution: {integrity: sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==}
-    peerDependencies:
-      redux: ^4
-    dependencies:
-      redux: 4.1.2
-    dev: false
-
   /redux/4.1.2:
     resolution: {integrity: sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==}
     dependencies:
@@ -15743,10 +15699,6 @@ packages:
   /require-main-filename/2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
     dev: true
-
-  /reselect/4.1.5:
-    resolution: {integrity: sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==}
-    dev: false
 
   /resolve-cwd/3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}

--- a/projects/fractally/pnpm-lock.yaml
+++ b/projects/fractally/pnpm-lock.yaml
@@ -97,7 +97,6 @@ importers:
       '@graphql-codegen/typescript-operations': 2.2.2
       '@graphql-codegen/typescript-react-query': ^3.4.0
       '@greymass/eosio': ^0.5.4
-      '@signalwire/core': ^3.7.1
       '@signalwire/js': ^3.10.2
       '@tailwindcss/forms': ^0.4.0
       '@types/node': ~16.11.0
@@ -128,7 +127,6 @@ importers:
     dependencies:
       '@fractally/components': link:../../packages/components
       '@greymass/eosio': 0.5.4
-      '@signalwire/core': 3.7.1
       '@signalwire/js': 3.10.2
       anchor-link: 3.3.5
       anchor-link-browser-transport: 3.2.5_anchor-link@3.3.5

--- a/projects/fractally/pnpm-lock.yaml
+++ b/projects/fractally/pnpm-lock.yaml
@@ -97,6 +97,7 @@ importers:
       '@graphql-codegen/typescript-operations': 2.2.2
       '@graphql-codegen/typescript-react-query': ^3.4.0
       '@greymass/eosio': ^0.5.4
+      '@signalwire/core': ^3.7.1
       '@signalwire/js': ^3.10.2
       '@tailwindcss/forms': ^0.4.0
       '@types/node': ~16.11.0
@@ -127,6 +128,7 @@ importers:
     dependencies:
       '@fractally/components': link:../../packages/components
       '@greymass/eosio': 0.5.4
+      '@signalwire/core': 3.7.1
       '@signalwire/js': 3.10.2
       anchor-link: 3.3.5
       anchor-link-browser-transport: 3.2.5_anchor-link@3.3.5


### PR DESCRIPTION
Turns out that if you specify `highlight-1-responsive` as the layout when creating the room via their API, it doesn't respond to the active speaker as it should. But if, during the call, you switch _into_ that layout using `room.setLayout({ room: "highlight-1-responsive" })`, it behaves as it should.